### PR TITLE
Added demonitor from caller to middle-man process when responding

### DIFF
--- a/src/gb_dyno_dist.erl
+++ b/src/gb_dyno_dist.erl
@@ -271,8 +271,10 @@ get_result(Mref, CReq, Results) ->
 		{nok, NewResults} ->
 		    get_result(Mref, CReq, NewResults);  
 		{ok, Response} ->
+		    erlang:demonitor(Mref, [flush]),
 		    Response;
 		{error, Reason} ->
+		    erlang:demonitor(Mref, [flush]),
 		    {error, Reason}
 	    end;
 	{'DOWN',Mref,_,_,Reason} ->


### PR DESCRIPTION
Fix issue with building up msg queue of caller with {'DOWN', ...} messages
